### PR TITLE
build: Use cmake build and install macros in rpm spec

### DIFF
--- a/dist/clementine.spec.in
+++ b/dist/clementine.spec.in
@@ -57,7 +57,7 @@ BuildRequires:  pkgconfig(libnotify)
 BuildRequires:  pkgconfig(libudf)
 
 # GStreamer codec dependencies
-Requires:       gstreamer1-plugins-ugly
+Requires:       gstreamer1-plugins-ugly-free
 
 %ifarch x86_64
 Requires:       gstreamer1(decoder-audio/x-vorbis)()(64bit)

--- a/dist/clementine.spec.in
+++ b/dist/clementine.spec.in
@@ -100,11 +100,11 @@ Features include:
 %build
 cd bin
 %{cmake} .. -DUSE_INSTALL_PREFIX=OFF -DBUNDLE_PROJECTM_PRESETS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-make %{?_smp_mflags}
+%{cmake_build}
 
 %install
 cd bin
-make install DESTDIR=$RPM_BUILD_ROOT
+%{cmake_install}
 rm -f $RPM_BUILD_ROOT/usr/share/icons/ubuntu-mono-{dark,light}/apps/24/clementine-panel*.png
 
 %clean


### PR DESCRIPTION
Starting with fedora 33, the cmake macro macro uses the cmake -B flag for
out-of-source builds. Additional cmake_build and cmake_install macros
were created and backported to support this migration.

https://fedoraproject.org/wiki/Changes/CMake_to_do_out-of-source_builds