### PR TITLE
build: Remove dependency on obsolete gstreamer1-plugins-ugly

### DIFF
--- a/dist/clementine.spec.in
+++ b/dist/clementine.spec.in
@@ -57,7 +57,7 @@ BuildRequires:  pkgconfig(libnotify)
 BuildRequires:  pkgconfig(libudf)
 
 # GStreamer codec dependencies
-Requires:       gstreamer1-plugins-ugly
+Requires:       gstreamer1-plugins-ugly-free
 
 %ifarch x86_64
 Requires:       gstreamer1(decoder-audio/x-vorbis)()(64bit)


### PR DESCRIPTION
In fedora 31, the gstreamer1-plugins-ugly package was removed. A
gstreamer1-plugins-ugly-free package was added in fedora 27 and
gstreamer1-plugins-ugly had depended on that before removal.

Note that there is still a gstreamer1-plugins-ugly package available
in rpmfusion.