### PR TITLE
build: Add libgpod for mac

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -890,6 +890,31 @@ jobs:
       - uses: actions/checkout@v1.2.0
       - name: Install dependencies
         run: brew bundle
+
+      - name: Build libgpod
+        shell: bash
+        env:
+          PERL_MM_USE_DEFAULT: 1
+        run: |
+          sudo cpan install XML::Parser
+          wget https://downloads.sourceforge.net/project/gtkpod/libgpod/libgpod-0.8/libgpod-0.8.3.tar.bz2
+          tar -xvf libgpod-0.8.3.tar.bz2
+          cd libgpod-0.8.3
+          wget https://raw.githubusercontent.com/macports/macports-ports/master/multimedia/libgpod/files/autogen.sh
+          wget https://raw.githubusercontent.com/macports/macports-ports/master/multimedia/libgpod/files/patch-tools-generic-callout.c.diff
+          wget http://files.strawberrymusicplayer.org/patches/libgpod-libplist.patch
+          patch -p0 < patch-tools-generic-callout.c.diff
+          patch -p1 < libgpod-libplist.patch
+          chmod u+x autogen.sh
+          ./autogen.sh
+          ./configure --disable-more-warnings \
+                      --disable-silent-rules \
+                      --disable-udev \
+                      --disable-pygobject \
+                      --with-python=no
+          make -j8
+          sudo make install
+
       - name: Fix liblastfm includes
         run: ln -s /usr/local/include/lastfm /usr/local/include/lastfm5
       - name: cmake

--- a/Brewfile
+++ b/Brewfile
@@ -17,3 +17,14 @@ brew 'protobuf'
 brew 'protobuf-c'
 brew 'qt@5'
 brew 'tomahawk-player/homebrew-tomahawkqt5/liblastfm'
+
+# These were added for libgpod support and can probably be removed if/when the
+# libgpod package is available.
+brew 'wget'
+brew 'libplist'
+brew 'gnome-common'
+brew 'gdk-pixbuf'
+brew 'intltool'
+brew 'autoconf'
+brew 'automake'
+brew 'gtk-doc'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1326,6 +1326,7 @@ if(HAVE_LIBLASTFM)
 endif(HAVE_LIBLASTFM)
 
 if(HAVE_LIBGPOD)
+  link_directories(${LIBGPOD_LIBRARY_DIRS})
   target_link_libraries(clementine_lib ${LIBGPOD_LIBRARIES})
 endif(HAVE_LIBGPOD)
 


### PR DESCRIPTION
This change was taken from Strawberry. When and if a homebrew libgpod
package becomes available, it can be replaced with that.

Reference: https://github.com/strawberrymusicplayer/strawberry/commit/f2c7df3a3b9aabf2b720c1f669ee28fdbb0bd257